### PR TITLE
feat: add more commands in lint

### DIFF
--- a/src/commands/lint.ts
+++ b/src/commands/lint.ts
@@ -8,18 +8,132 @@ import { DiagnosticsManager } from "../utils/diagnosticsManager";
 const execFileAsync = promisify(execFile);
 
 export async function runLintCommand(): Promise<void> {
-  const editor = vscode.window.activeTextEditor;
-  if (!editor) {
-    throw new Error("No active editor found");
-  }
+  const options = await vscode.window.showQuickPick(
+    [
+      "Lint Selected File",
+      "Lint Multiple Files",
+      "Lint Entire Workspace",
+      "Lint Entire Workspace (Ignoring Certain Paths)",
+      "Lint by Extension",
+      "Fix Lint Issues"
+    ],
+    { placeHolder: "Choose a linting option" }
+  );
 
-  const filePath = editor.document.uri.fsPath;
-  await runLint(filePath);
+  if (!options) return;
+
+  switch (options) {
+    case "Lint Selected File":
+      await lintSingleFile();
+      break;
+    case "Lint Multiple Files":
+      await lintMultipleFiles();
+      break;
+    case "Lint Entire Workspace":
+      await lintWorkspace();
+      break;
+    case "Lint Entire Workspace (Ignoring Certain Paths)":
+      await lintWorkspaceWithIgnore();
+      break;
+    case "Lint by Extension":
+      await lintByExtension();
+      break;
+    case "Fix Lint Issues":
+      await fixLintIssues();
+      break;
+  }
 }
 
-async function runLint(filePath: string): Promise<void> {
+async function lintSingleFile(): Promise<void> {
+  const editor = vscode.window.activeTextEditor;
+  if (!editor) {
+    vscode.window.showErrorMessage("No active editor found.");
+    return;
+  }
+  await runLint([editor.document.uri.fsPath]);
+}
+
+async function lintMultipleFiles(): Promise<void> {
+  const files = await vscode.window.showOpenDialog({
+    canSelectMany: true,
+    filters: { JSON: ["json"] },
+    openLabel: "Select Schema File(s) for Linting",
+  });
+
+  if (!files || files.length === 0) {
+    vscode.window.showErrorMessage("No files selected.");
+    return;
+  }
+
+  await runLint(files.map(f => f.fsPath));
+}
+
+async function lintWorkspace(): Promise<void> {
+  const workspaceFolders = vscode.workspace.workspaceFolders;
+  if (!workspaceFolders) {
+    vscode.window.showErrorMessage("No workspace opened.");
+    return;
+  }
+
+  const workspacePath = workspaceFolders[0].uri.fsPath;
+  await runLint([workspacePath]);
+}
+
+async function lintWorkspaceWithIgnore(): Promise<void> {
+  const workspaceFolders = vscode.workspace.workspaceFolders;
+  if (!workspaceFolders) {
+    vscode.window.showErrorMessage("No workspace opened.");
+    return;
+  }
+
+  const workspacePath = workspaceFolders[0].uri.fsPath;
+
+  const ignorePaths = await vscode.window.showInputBox({
+    placeHolder: "Enter paths to ignore (comma-separated)",
+    prompt: "Example: path/to/ignore1, path/to/ignore2",
+  });
+
+  const args = [workspacePath];
+  if (ignorePaths) {
+    ignorePaths.split(",").forEach(path => args.push("--ignore", path.trim()));
+  }
+
+  await runLint(args);
+}
+
+async function lintByExtension(): Promise<void> {
+  const extension = await vscode.window.showInputBox({
+    placeHolder: "Enter file extension (e.g., .schema.json)",
+    prompt: "Specify which file types to lint",
+  });
+
+  if (!extension) {
+    vscode.window.showErrorMessage("No extension provided.");
+    return;
+  }
+
+  await runLint(["--extension", extension]);
+}
+
+async function fixLintIssues(): Promise<void> {
+  const files = await vscode.window.showOpenDialog({
+    canSelectMany: true,
+    filters: { JSON: ["json"] },
+    openLabel: "Select Schema File(s) to Auto-Fix",
+  });
+
+  if (!files || files.length === 0) {
+    vscode.window.showErrorMessage("No files selected.");
+    return;
+  }
+
+  const filePaths = files.map(f => f.fsPath);
+  await runLint([...filePaths, "--fix"]);
+}
+
+async function runLint(args: string[]): Promise<void> {
   const cli = await CliHelper.getInstance().getCliCommand();
-  const args = ["lint", filePath];
+  const fullArgs = ["lint", ...args];
 
   await vscode.window.withProgress(
     {
@@ -31,7 +145,7 @@ async function runLint(filePath: string): Promise<void> {
       try {
         const { stdout, stderr } = await execFileAsync(cli.command, [
           ...cli.args,
-          ...args,
+          ...fullArgs,
         ]);
         const output = `${stdout}\n${stderr}`.trim();
 

--- a/src/status/statusBarManager.ts
+++ b/src/status/statusBarManager.ts
@@ -24,15 +24,32 @@ export class StatusBarManager {
   updateStatus(message: string, type: "success" | "error" | "working"): void {
     switch (type) {
       case "success":
-        this.statusBarItem.text = "$(check) JSON Schema";
+        this.statusBarItem.text = "$(check) JSON Schema - Success";
         this.statusBarItem.tooltip = message;
         break;
       case "error":
-        this.statusBarItem.text = "$(error) JSON Schema";
+        this.statusBarItem.text = "$(error) JSON Schema - Error";
         this.statusBarItem.tooltip = message;
         break;
       case "working":
-        this.statusBarItem.text = "$(sync~spin) JSON Schema";
+        this.statusBarItem.text = "$(sync~spin) JSON Schema - Processing...";
+        this.statusBarItem.tooltip = message;
+        break;
+    }
+  }
+
+  updateLintStatus(message: string, type: "success" | "error" | "working"): void {
+    switch (type) {
+      case "success":
+        this.statusBarItem.text = "$(check) JSON Lint - No Issues";
+        this.statusBarItem.tooltip = message;
+        break;
+      case "error":
+        this.statusBarItem.text = "$(alert) JSON Lint - Issues Found";
+        this.statusBarItem.tooltip = message;
+        break;
+      case "working":
+        this.statusBarItem.text = "$(sync~spin) JSON Lint - Running...";
         this.statusBarItem.tooltip = message;
         break;
     }


### PR DESCRIPTION
This PR focuses on completing the lint functionality for the extension based on this [doc](https://github.com/sourcemeta/jsonschema/blob/main/docs/lint.markdown) and [discussion](https://json-schema.slack.com/archives/C8C4UBXDF/p1738853417367429?thread_ts=1738590781.293879&cid=C8C4UBXDF)

Feature | Status
-- | --
Lint a single schema file | ✅ 
Lint multiple schema files | ✅ 
Lint every .json file in a given directory (recursively) | ✅ 
Lint while ignoring certain directories | ✅ 
Lint files with a specific extension (e.g., .schema.json) | ✅ 
Automatically fix lint issues (--fix option) | ✅ 

[Screencast from 2025-02-13 16-17-15.webm](https://github.com/user-attachments/assets/50b17d65-35a4-4ab2-83d9-914f251c9876)


